### PR TITLE
feat: Add Marketo activities object sample

### DIFF
--- a/marketo/amp.yaml
+++ b/marketo/amp.yaml
@@ -6,7 +6,7 @@ integrations:
       objects:
         - objectName: leads
           destination: marketoWebhook
-          schedule: "0 */6 * * *" # every 6 hours
+          schedule: "*/10 * * * *" # Every 10 minutes
           requiredFields:
             - fieldName: id
             - fieldName: firstName
@@ -19,10 +19,7 @@ integrations:
         # https://developer.adobe.com/marketo-apis/api/mapi/#tag/Activities/operation/getLeadActivitiesUsingGET
         - objectName: activities
           destination: marketoWebhook
-          schedule: "0 */6 * * *" # every 6 hours
-          backfill:
-            defaultPeriod:
-              fullHistory: true
+          schedule: "*/10 * * * *" # Every 10 minutes
           requiredFields:
             - fieldName: id
             - fieldName: leadId
@@ -34,7 +31,7 @@ integrations:
         # https://developer.adobe.com/marketo-apis/api/mapi/#operation/getCampaignsUsingGET
         - objectName: campaigns
           destination: marketoWebhook
-          schedule: "0 */6 * * *" # every 6 hours
+          schedule: "*/10 * * * *" # Every 10 minutes
           requiredFields:
             - fieldName: active
             - fieldName: id

--- a/marketo/amp.yaml
+++ b/marketo/amp.yaml
@@ -4,8 +4,6 @@ integrations:
     provider: marketo
     read:
       objects:
-        # More fields can be seen here
-        # https://developer.adobe.com/marketo-apis/api/mapi/#operation/getLeadsByFilterUsingGET
         - objectName: leads
           destination: marketoWebhook
           schedule: "0 */6 * * *" # every 6 hours
@@ -16,6 +14,21 @@ integrations:
             - fieldName: email
           optionalFields:
             - fieldName: address
+
+        # More fields can be seen here
+        # https://developer.adobe.com/marketo-apis/api/mapi/#tag/Activities/operation/getLeadActivitiesUsingGET
+        - objectName: activities
+          destination: marketoWebhook
+          schedule: "0 */6 * * *" # every 6 hours
+          backfill:
+            defaultPeriod:
+              fullHistory: true
+          requiredFields:
+            - fieldName: id
+            - fieldName: leadId
+            - fieldName: marketoGUID
+            - fieldName: activityTypeId
+          optionalFieldsAuto: all
 
         # More fields can be seen here
         # https://developer.adobe.com/marketo-apis/api/mapi/#operation/getCampaignsUsingGET


### PR DESCRIPTION
- Adds `activities` object sample.
- Removes the leads documentation link comment. The fields observed in this link are no longer available nor supported.