### PR TITLE
Fix the indentation of salesforce's write key

### DIFF
--- a/salesforce/amp.yaml
+++ b/salesforce/amp.yaml
@@ -42,7 +42,7 @@ integrations:
           # All other fields in a Lead are optional,
           # Customers can pick from all of them.
           optionalFieldsAuto: all
-      write:
-        objects:
-          # Create a new lead in Salesforce whenever we make an API request.
-          - objectName: lead
+    write:
+      objects:
+        # Create a new lead in Salesforce whenever we make an API request.
+        - objectName: lead


### PR DESCRIPTION
When hitting https://docs.withampersand.com/reference/write/write-records?playground=open the salesforce integration will return an error that the api key is not set up yet for write permission. Apparently cuz the indentation of `write` was off