### PR TITLE
feat(paddle): add read/write/proxy amp.yaml

### DIFF
--- a/paddle/amp.yaml
+++ b/paddle/amp.yaml
@@ -1,10 +1,46 @@
-# Proxy-only Paddle integration sample.
-# This sample intentionally omits Read Actions and Write Actions.
-
 specVersion: 1.0.0
 integrations:
-  - name: paddleProxy
-    displayName: Paddle proxy
+  - name: readAndWritePaddle
+    displayName: Paddle read and write
     provider: paddle
+
+    read:
+      objects:
+        - objectName: products
+          destination: paddleWebhook
+          schedule: "*/10 * * * *"
+          # Field names can be found at https://developer.paddle.com/api-reference/products/list-products
+          requiredFields:
+            - fieldName: id
+            - fieldName: name
+            - fieldName: status
+          optionalFieldsAuto: all
+
+        - objectName: prices
+          destination: paddleWebhook
+          schedule: "*/10 * * * *"
+          # Field names can be found at https://developer.paddle.com/api-reference/prices/list-prices
+          requiredFields:
+            - fieldName: id
+            - fieldName: product_id
+            - fieldName: status
+          optionalFieldsAuto: all
+
+        - objectName: transactions
+          destination: paddleWebhook
+          schedule: "*/10 * * * *"
+          # Field names can be found at https://developer.paddle.com/api-reference/transactions/list-transactions
+          requiredFields:
+            - fieldName: id
+            - fieldName: customer_id
+            - fieldName: status
+          optionalFieldsAuto: all
+
+    write:
+      objects:
+        - objectName: products
+        - objectName: prices
+        - objectName: customers
+
     proxy:
       enabled: true

--- a/paddle/amp.yaml
+++ b/paddle/amp.yaml
@@ -1,0 +1,10 @@
+# Proxy-only Paddle integration sample.
+# This sample intentionally omits Read Actions and Write Actions.
+
+specVersion: 1.0.0
+integrations:
+  - name: paddleProxy
+    displayName: Paddle proxy
+    provider: paddle
+    proxy:
+      enabled: true


### PR DESCRIPTION
Adds `samples/paddle/amp.yaml` as a representative Paddle manifest that demonstrates the connector's supported action types without enumerating every supported object.

- Declares Read Actions for `products`, `prices`, and `transactions`.
- Declares Write Actions for `products`, `prices`, and `customers`.
- Enables Proxy Actions.
- Pairs with amp-labs/docs#618.
- Harness evidence: run `2026-05-30T13-26-55-165Z-paddle` against this exact file. Manifest sha256 `877ece69931c89ac47a8672a2222ecec900a32d6c872d919b70f4e924878f8c8`; modes completed: `proxy-smoke` (deploy + connection + installation + proxy + cleanup); findings: 0; live-key detected (`pdl_live_`), writes blocked by harness rule.
- Does not runtime-validate Paddle Read delivery or Write execution; current evidence verifies deploy + connection + installation + proxy + cleanup.