### PR TITLE
feat(dovetail): add proxy-only sample

### DIFF
--- a/dovetail/amp.yaml
+++ b/dovetail/amp.yaml
@@ -1,0 +1,11 @@
+# Proxy-only Dovetail integration sample.
+# Per the connector catalog, Dovetail is proxy-only (Read and Write Actions
+# are not supported), so this manifest enables Proxy Actions only.
+
+specVersion: 1.0.0
+integrations:
+  - name: dovetailProxy
+    displayName: Dovetail proxy
+    provider: dovetail
+    proxy:
+      enabled: true


### PR DESCRIPTION
## Summary

- Add a proxy-only Dovetail sample manifest.
- Leave read, write, and subscribe out because the Dovetail connector is proxy-only.

## Verification

- Harness proxy smoke passed against this exact sample file.
- Run: `2026-05-30T20-39-56-568Z-dovetail`
- Manifest sha256: `1d49908b7cc70ff089ac70856341f3b8d6e3ef31465a077e4e6bbb8c0db95909`
- Baseline and proxy `GET /v1/projects?limit=1` both returned 200; cleanup passed.

Merge this sample before the docs guide so the docs sample link resolves.
