### PR TITLE
feat(fourfour): add read + proxy sample

### DIFF
--- a/fourfour/amp.yaml
+++ b/fourfour/amp.yaml
@@ -1,0 +1,24 @@
+# Read + Proxy sample for the Four/Four connector (OAuth2).
+# Demonstrates Read Actions (Conversations backfill delivery) and Proxy Actions
+# against https://fourfour.ai. Four/Four does not support Write or Subscribe.
+specVersion: 1.0.0
+integrations:
+  - name: fourfourReadProxy
+    displayName: Four/Four read + proxy
+    provider: fourFour
+    read:
+      objects:
+        - objectName: Conversations
+          destination: fourfourWebhook
+          schedule: "0 0 * * *"
+          requiredFields:
+            - fieldName: id
+          optionalFieldsAuto: all
+          # Conversations does not support incremental filtering in the connector,
+          # so fullHistory is intentional. Use a bounded defaultPeriod only for
+          # objects with incremental fields, such as Contacts or Accounts.
+          backfill:
+            defaultPeriod:
+              fullHistory: true
+    proxy:
+      enabled: true


### PR DESCRIPTION
Adds a manifest sample for the Four/Four connector. The Four/Four provider guide links to `fourfour/amp.yaml` as its example, but that file doesn't exist in this repo yet; this adds it.

The sample covers the connector's supported actions and nothing it doesn't: Read (Conversations) and Proxy. Four/Four supports neither Write nor Subscribe, so neither appears.

It was verified live against a real Four/Four account through Ampersand before publishing:
- Read delivery: one Conversations record was delivered through the read pipeline to a webhook destination (`verifiedRead: ["Conversations"]`).
- Proxy: `GET /odata/Conversations` returns 200 through the proxy; the same call with no auth returns 401, so the proxy pass is auth-meaningful.

Conversations uses `fullHistory` backfill on purpose: the connector exposes no incremental date field for it, so a bounded period would be silently ignored and read in full anyway. Objects that do have an incremental field (e.g. Contacts, Accounts) can use a bounded `defaultPeriod` instead.
