### PR TITLE
docs: add Gusto sample manifest

### DIFF
--- a/gusto/amp.yaml
+++ b/gusto/amp.yaml
@@ -1,0 +1,21 @@
+# Read + Write + Proxy sample for the Gusto connector (OAuth2).
+# Demonstrates Read Actions for companies, Write Actions for employees, and Proxy Actions.
+specVersion: 1.0.0
+integrations:
+  - name: gustoReadWriteProxy
+    displayName: Gusto read, write, and proxy
+    provider: gusto
+    read:
+      objects:
+        - objectName: companies
+          destination: gustoWebhook
+          schedule: "0 0 * * *"
+          requiredFields:
+            - fieldName: uuid
+            - fieldName: name
+          optionalFieldsAuto: all
+    write:
+      objects:
+        - objectName: employees
+    proxy:
+      enabled: true


### PR DESCRIPTION
## Summary

Adds a Gusto sample manifest at `gusto/amp.yaml`.

## Why

The Gusto provider guide links to this sample path, but the file did not exist in the samples repo.

The sample is intentionally small and representative:

- Read Actions: `companies`
- Write Actions: `employees`
- Proxy Actions: enabled

## Verification

```sh
git diff --check
ruby -e 'require "psych"; p Psych.load_file("gusto/amp.yaml").fetch("specVersion")'
```
