### PR TITLE
samples(servicenow): rename objects to bare entity names

### DIFF
--- a/servicenow/amp.yaml
+++ b/servicenow/amp.yaml
@@ -4,7 +4,7 @@ integrations:
     provider: serviceNow
     read:
       objects:
-        - objectName: now/table/incident
+        - objectName: incident
           destination: serviceNowWebhook
           schedule: "*/30 * * * *" # Every 30 minutes
           requiredFields:
@@ -15,18 +15,7 @@ integrations:
           optionalFields:
             - fieldName: impact
 
-        - objectName: now/table/cmdb_ci_email_server
-          destination: serviceNowWebhook
-          schedule: "*/30 * * * *" # Every 30 minutes
-          requiredFields:
-            - fieldName: id
-            - fieldName: operational_status
-            - fieldName: sys_domain
-            - fieldName: sys_class_name
-          optionalFields:
-            - fieldName: city
-
-        - objectName: now/contact
+        - objectName: contact
           destination: serviceNowWebhook
           schedule: "*/30 * * * *" # Every 30 minutes
           requiredFields:
@@ -37,6 +26,6 @@ integrations:
 
     write:
       objects:
-        - objectName: now/contact
-        - objectName: now/table/incident
-        - objectName: now/consumer
+        - objectName: contact
+        - objectName: incident
+        - objectName: consumer


### PR DESCRIPTION
## Summary

Updates the ServiceNow sample to match the new object-naming convention introduced in the connectors repo's `jk-servicenow-namings` branch. Objects are now referenced by their **bare entity name** instead of their full REST API path.

## Changes

- `now/table/incident` → `incident`
- `now/contact` → `contact`
- `now/consumer` → `consumer`
- **Removed** the `now/table/cmdb_ci_email_server` read block. Arbitrary Table API tables are no longer supported under the new naming — only an explicit list of named tables (which does not include `cmdb_ci_email_server`) — and it has no bare-name equivalent.

## Related

Companion to the docs guide update: amp-labs/docs#629

🤖 Generated with [Claude Code](https://claude.com/claude-code)