### PR TITLE
[ENG-4141] feat(zoho): add Zoho Mail subscribe sample

### DIFF
--- a/zoho/mail/amp.yaml
+++ b/zoho/mail/amp.yaml
@@ -1,0 +1,45 @@
+specVersion: 1.0.0
+integrations:
+  - name: zoho-mail-subscribe
+    provider: zoho
+    module: mail
+    read: # Read action is required for subscribe actions
+      objects:
+        - objectName: messages
+          destination: zohoMailWebhook
+          # schedule: "*/30 * * * *" # every 30 minutes
+          requiredFields:
+            - fieldName: messageId
+            - fieldName: subject
+            - fieldName: fromAddress
+            - fieldName: receivedTime
+          optionalFields:
+            - fieldName: toAddress
+            - fieldName: summary
+        - objectName: tasks
+          destination: zohoMailWebhook
+          requiredFields:
+            - fieldName: id
+            - fieldName: title
+          optionalFieldsAuto: all
+    subscribe:
+      objects:
+        # Zoho Mail only sends webhooks for newly received emails, so
+        # messages support createEvent only.
+        - objectName: messages
+          destination: zohoMailWebhook
+          inheritFieldsAndMapping: true
+          createEvent:
+            enabled: always
+        # Task webhooks fire on group task activity; the task "action"
+        # is mapped to create/update/delete events.
+        - objectName: tasks
+          destination: zohoMailWebhook
+          inheritFieldsAndMapping: true
+          createEvent:
+            enabled: always
+          updateEvent:
+            enabled: always
+            watchFieldsAuto: all
+          deleteEvent:
+            enabled: always


### PR DESCRIPTION
## Summary

Adds `zoho/mail/amp.yaml`: a sample manifest for the Zoho Mail module (`module: mail`) with read and subscribe actions for `messages` and `tasks`.

Zoho Mail only sends webhooks for newly received emails, so `messages` subscribe to `createEvent` only; task webhooks map the task action to create/update/delete events. Zoho Mail has no webhook-subscription API — the outgoing webhook is configured by hand in the Zoho Mail console (Settings > Integrations > Developer Space > Outgoing Webhooks).

Companion PRs: amp-labs/connectors#3315, amp-labs/server#7005, amp-labs/docs#689 (the docs provider guide links to this sample).

🤖 Generated with [Claude Code](https://claude.com/claude-code)